### PR TITLE
Do not load not loaded modules

### DIFF
--- a/test/telemetry_registry_SUITE.erl
+++ b/test/telemetry_registry_SUITE.erl
@@ -22,13 +22,13 @@ end_per_suite(_Config) ->
 discovers_all_events(_Config) ->
     {ok, _Pid} = telemetry_registry:start_link([{application, test_app}]),
     Events = telemetry_registry:list_events(),
-    ?assert(9 =:= erlang:length(Events)).
+    ?assertEqual(9, erlang:length(Events)).
 
 determines_spannable_events(_Config) ->
     {ok, _Pid} = telemetry_registry:start_link([{application, test_app}]),
     Events = telemetry_registry:spannable_events(),
-    ?assert(#{
+    ?assertEqual(#{
               [test_app,handler] => [start,stop,failure],
               [test_child_app,extra_long,handler] => [start,stop]
-             } =:= Events).
+             }, Events).
 


### PR DESCRIPTION
For not loaded modules it will try to find their path in the code path and load attributes from the BEAM file without loading module itself.

This is followup of https://github.com/beam-telemetry/telemetry_registry/pull/1#discussion_r391331906