### PR TITLE
fix: do not load unloaded modules

### DIFF
--- a/test/telemetry_registry_SUITE.erl
+++ b/test/telemetry_registry_SUITE.erl
@@ -8,7 +8,8 @@
 all() -> [
   discovers_all_events,
   determines_spannable_events,
-  supports_event_definitions
+  supports_event_definitions,
+  dont_load_unloaded_modules
 ].
 
 init_per_suite(Config) ->
@@ -44,3 +45,9 @@ supports_event_definitions(_Config) ->
     ?assert(is_binary(Description)),
     ?assert(is_binary(Measurements)),
     ?assert(is_binary(Metadata)).
+
+dont_load_unloaded_modules(_Config) ->
+    code:delete(memsup),
+    ?assertNot(code:is_loaded(memsup)),
+    _ = telemetry_registry:discover_all(),
+    ?assertNot(code:is_loaded(memsup)).


### PR DESCRIPTION
Instead it will find compiled BEAM file and extract the values from there.

Unfortunately this causes substantial performance impact on non-loaded modules, so this approach need to be discussed further.

This is follow up of https://github.com/beam-telemetry/telemetry_registry/pull/1#discussion_r391331906