### PR TITLE
Fix ordering of telemetry events at compile-time

### DIFF
--- a/lib/telemetry_registry.ex
+++ b/lib/telemetry_registry.ex
@@ -204,7 +204,7 @@ defmodule TelemetryRegistry do
 
   defp get_events(module) do
     try do
-      Module.get_attribute(module, :telemetry_event, [])
+      Module.get_attribute(module, :telemetry_event, []) |> Enum.reverse()
     rescue
       _ ->
         module.__info__(:attributes)

--- a/test/support/test_elixir_app.ex
+++ b/test/support/test_elixir_app.ex
@@ -2,7 +2,14 @@ defmodule TestElixirApp do
   use TelemetryRegistry
 
   telemetry_event %{
-    event: [:test_elixir_app, :single, :event],
+    event: [:test_elixir_app, :event, :start],
+    description: "emitted when this event happens",
+    measurements: "%{duration: non_neg_integer()}",
+    metadata: "%{status: status(), name: String.t()}"
+  }
+
+  telemetry_event %{
+    event: [:test_elixir_app, :event, :stop],
     description: "emitted when this event happens",
     measurements: "%{duration: non_neg_integer()}",
     metadata: "%{status: status(), name: String.t()}"

--- a/test/telemetry_registry_test.exs
+++ b/test/telemetry_registry_test.exs
@@ -3,7 +3,12 @@ defmodule TelemetryRegistryTest do
 
   test "multiple event attributes are persisted for Elixir modules along with docs" do
     expected_docs = """
-    * `[:test_elixir_app, :single, :event]`
+    * `[:test_elixir_app, :event, :start]`
+      * Description: emitted when this event happens
+      * Measurements: `%{duration: non_neg_integer()}`
+      * Metadata: `%{status: status(), name: String.t()}`
+
+    * `[:test_elixir_app, :event, :stop]`
       * Description: emitted when this event happens
       * Measurements: `%{duration: non_neg_integer()}`
       * Metadata: `%{status: status(), name: String.t()}`
@@ -13,5 +18,14 @@ defmodule TelemetryRegistryTest do
     docs = TelemetryRegistry.docs_for(TestElixirApp)
 
     assert docs == expected_docs
+    assert {:docs_v1, _, :elixir, _, %{"en" => module_doc}, _, _} = Code.fetch_docs(TestElixirApp)
+
+    assert module_doc == """
+           Information about the module.
+
+           ## Telemetry
+
+           #{expected_docs}
+           """
   end
 end


### PR DESCRIPTION
Fixes the ordering when using the `telemetry_docs` macro, since module attributes are collected and stored in reverse order.