### PR TITLE
Include .formatter.exs in hex package

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -64,7 +64,7 @@ defmodule TelemetryRegistry.MixProject do
       description: "Registry and helpers for Telemetry events",
       build_tools: ["rebar3", "mix"],
       files:
-        ~w(lib mix.exs README.md LICENSE CODEOWNERS rebar.config rebar.lock VERSION src),
+        ~w(lib mix.exs README.md LICENSE CODEOWNERS rebar.config rebar.lock VERSION src .formatter.exs),
       licenses: ["Apache-2.0"],
       links: %{"GitHub" => "https://github.com/beam-telemetry/telemetry_registry"}
     ]


### PR DESCRIPTION
I tried to use `import_deps: [:telemetry_registry]` in my `.formatter.exs` so `telemetry_event/1` didn't need parentheses, but the formatter was adding parentheses anyways. It turns out that it's because `.formatter.exs` isn't being included as part of the hex package. 

I double-checked and can confirm that .formatter.exs is included in other packages like plug: https://preview.hex.pm/preview/plug/1.13.6/show/.formatter.exs#L14.