### PR TITLE
Get rid of charlist deprecation warnings in Elixir 1.17

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -80,13 +80,13 @@ defmodule TelemetryRegistry.MixProject do
   end
 
   defp load_config do
-    {:ok, config} = :file.consult('rebar.config')
+    {:ok, config} = :file.consult("rebar.config")
 
     config
   end
 
   defp load_app do
-    {:ok, [{:application, name, desc}]} = :file.consult('src/telemetry_registry.app.src')
+    {:ok, [{:application, name, desc}]} = :file.consult("src/telemetry_registry.app.src")
 
     {name, desc}
   end


### PR DESCRIPTION
```
    warning: single-quoted strings represent charlists. Use ~c"" if you indeed want a charlist or use "" instead
    │
 83 │     {:ok, config} = :file.consult('rebar.config')
    │                                   ~
    │
    └─ deps/telemetry_registry/mix.exs:83:35
    warning: single-quoted strings represent charlists. Use ~c"" if you indeed want a charlist or use "" instead
    │
 89 │     {:ok, [{:application, name, desc}]} = :file.consult('src/telemetry_registry.app.src')
    │                                                         ~
    │
    └─ telemetry_registry/mix.exs:89:57
```